### PR TITLE
Add GetDynamicRuntimeConfig to fake runtime

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/fake/fake_runtime.go
+++ b/staging/src/k8s.io/cri-client/pkg/fake/fake_runtime.go
@@ -366,3 +366,7 @@ func (f *RemoteRuntime) RuntimeConfig(ctx context.Context, req *kubeapi.RuntimeC
 
 	return resp, nil
 }
+
+func (f *RemoteRuntime) GetDynamicRuntimeConfig(*kubeapi.DynamicRuntimeConfigRequest, kubeapi.RuntimeService_GetDynamicRuntimeConfigServer) error {
+	return nil
+}


### PR DESCRIPTION
Fixes build issues with "make".